### PR TITLE
Redirect to the latest version of the docs.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <meta name="google-site-verification" content="HHUmsTvlB1VxxD21_ZnvavI0yH_-iV5nnsYshGbwNAU" />
-    <meta http-equiv="refresh" content="0; url=0.1.0-SNAPSHOT" />
+    <meta http-equiv="refresh" content="0; url=latest" />
   </head>
   <body>
   </body>


### PR DESCRIPTION
Now that we have the `latest` symlink, redirect from the homepage to the latest
version of the docs rather than hardcoding a specific version.

The docs themselves will specify what version of JanusGraph they apply to, so
there won't be any user confusion, and they'll always have the latest version of
the docs.

Once we have several versions, we'll update the index page to instead list all
the available doc versions and let the user choose explicitly.