### PR TITLE
Add robots.txt to hide old SNAPSHOT docs in search

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /0.1.0-SNAPSHOT/


### PR DESCRIPTION
The old documentation is showing up in search results which may be confusing to users. This change will hopefully remove the old results, while making the `/latest/` docs more prominent, which would be more helpful to users looking for recent JanusGraph information.