### PR TITLE
Adds a shield for easily seeing the website status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # docs.janusgraph.org
 
+[![Website][website-shield]][website-link]
+
+[website-shield]: https://img.shields.io/website-up-down-green-red/http/docs.janusgraph.org.svg?label=docs.janusgraph.org
+[website-link]: http://docs.janusgraph.org
+
 This repository contains the _generated_ documentation which is served on
 http://docs.janusgraph.org . To update the documentation for a particular
 version of JanusGraph, do not send a PR manually updating HTML files, because


### PR DESCRIPTION
This badge shows at a glance whether the website is up or down; it could be
down for any number of reasons, e.g., a DNS misconfiguration on the part of the
domain owner or GitHub's hosting, or inability to reach the GitHub servers
hosting the website.

This visual indicator will allow us to more quickly notice the issue and fix it.

Note: this change was adapted from an analogous change to the other website repo: https://github.com/JanusGraph/janusgraph.org/pull/22 