### PR TITLE
Add instructions for building preview on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,19 @@ those changes will be overwritten in the next docs update.
 
 Instead, please do the following:
 
-* modify the source AsciiDoc files in
-  [`janusgraph/docs`](https://github.com/janusgraph/janusgraph/tree/master/docs)
-* build the docs using
-  [`janusgraph/docs/build-and-copy-docs.sh`](https://github.com/JanusGraph/janusgraph/blob/master/docs/build-and-copy-docs.sh)
-  and then create a PR using the output files from this script
+1. modify the source AsciiDoc files in
+   [`janusgraph/docs`](https://github.com/janusgraph/janusgraph/tree/master/docs)
+1. build the docs using
+   [`janusgraph/docs/build-and-copy-docs.sh`](https://github.com/JanusGraph/janusgraph/blob/master/docs/build-and-copy-docs.sh)
+1. preview the output files from the script above locally in your browser to
+   verify that everything looks as expected
+1. create a feature branch with these files to be used for your PR
+1. also create a `gh-pages` branch to point to the same commit as your feature
+   branch for the preview site
+1. publish a [preview of your changes on
+   GitHub](https://github.com/JanusGraph/janusgraph.org/blob/master/README.md#preview-via-github),
+   making appropriate substitutions in the instructions, i.e,
+   `s/janusgraph.org/docs.janusgraph.org/g`, so that others can preview it
+   easily by pushing the `gh-pages` branch with your HTML pages to your fork
+1. create a PR using your **feature branch** and link to your preview site so
+   that others can see the changes without having to rebuild your PR manually


### PR DESCRIPTION
These instructions will help folks to build a preview on GitHub so that all PR
reviewers don't have to manually download PR and build the docs to preview the
proposed changes.

This is to help with previewing changes to http://docs.janusgraph.org such as https://github.com/JanusGraph/janusgraph/pull/370