### PR TITLE
Use HTTPS urls for docs.janusgraph.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![Website][website-shield]][website-link]
 
-[website-shield]: https://img.shields.io/website-up-down-green-red/http/docs.janusgraph.org.svg?label=docs.janusgraph.org
-[website-link]: http://docs.janusgraph.org
+[website-shield]: https://img.shields.io/website-up-down-green-red/https/docs.janusgraph.org.svg?label=docs.janusgraph.org
+[website-link]: https://docs.janusgraph.org
 
 This repository contains the _generated_ documentation which is served on
-http://docs.janusgraph.org . To update the documentation for a particular
+https://docs.janusgraph.org . To update the documentation for a particular
 version of JanusGraph, do not send a PR manually updating HTML files, because
 those changes will be overwritten in the next docs update.
 


### PR DESCRIPTION
This site has supported HTTPS for a while.