### PR TITLE
Change domain to old docs domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-docs.janusgraph.org
+old-docs.janusgraph.org

--- a/README.md
+++ b/README.md
@@ -1,30 +1,11 @@
-# docs.janusgraph.org
+# old-docs.janusgraph.org
 
 [![Website][website-shield]][website-link]
 
-[website-shield]: https://img.shields.io/website-up-down-green-red/https/docs.janusgraph.org.svg?label=docs.janusgraph.org
-[website-link]: https://docs.janusgraph.org
+[website-shield]: https://img.shields.io/website-up-down-green-red/https/old-docs.janusgraph.org.svg?label=old-docs.janusgraph.org
+[website-link]: https://old-docs.janusgraph.org
 
 This repository contains the _generated_ documentation which is served on
-https://docs.janusgraph.org . To update the documentation for a particular
-version of JanusGraph, do not send a PR manually updating HTML files, because
-those changes will be overwritten in the next docs update.
+https://old-docs.janusgraph.org .
 
-Instead, please do the following:
-
-1. modify the source AsciiDoc files in
-   [`janusgraph/docs`](https://github.com/janusgraph/janusgraph/tree/master/docs)
-1. build the docs using
-   [`janusgraph/docs/build-and-copy-docs.sh`](https://github.com/JanusGraph/janusgraph/blob/master/docs/build-and-copy-docs.sh)
-1. preview the output files from the script above locally in your browser to
-   verify that everything looks as expected
-1. create a feature branch with these files to be used for your PR
-1. also create a `gh-pages` branch to point to the same commit as your feature
-   branch for the preview site
-1. publish a [preview of your changes on
-   GitHub](https://github.com/JanusGraph/janusgraph.org/blob/master/README.md#preview-via-github),
-   making appropriate substitutions in the instructions, i.e,
-   `s/janusgraph.org/docs.janusgraph.org/g`, so that others can preview it
-   easily by pushing the `gh-pages` branch with your HTML pages to your fork
-1. create a PR using your **feature branch** and link to your preview site so
-   that others can see the changes without having to rebuild your PR manually
+This documentation repository serves only for historical record only. Current JanusGraph documentation is served on [`janusgraph/docs.janusgraph.org`](https://github.com/janusgraph/docs.janusgraph.org) repository.


### PR DESCRIPTION
Before we can launch new documentation on `docs.janusgraph.org` domain we should stop using it here.

After this PR is merged we should go fast and add CNAME with `docs.janusgraph.org` into main janusgraph repository. 

After that we should rename this repository name to `old-docs.janusgraph.org` to avoid future confusion.

Later we should add DNS record for `old-docs.janusgraph.org` to point to GitHub ips. (this step should be made by The Linux Foundation)

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>